### PR TITLE
fix: Handle non-empty directories when moving files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,14 @@ name = "file-organizer"
 version = "0.1.0"
 dependencies = [
  "directories",
+ "fs_extra",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 
 [dependencies]
 directories = "4.0.1"
+fs_extra = "1.3.0"
 

--- a/src/utils/move_file.rs
+++ b/src/utils/move_file.rs
@@ -10,10 +10,28 @@ pub fn move_file(from: PathBuf, to: String) {
 
   if from.is_dir() {
     let mut options = dir::CopyOptions::new();
-    options.copy_inside = true;
-    dir::move_dir(&from, &to, &options).expect("unable to move");
+    options.copy_inside = true;  // flattens contents into `to`
+    dir::move_dir(&from, &to, &options)
+      .map_err(|e| {
+        format!(
+          "Failed to move directory from '{}' into '{}': {}",
+          from.display(),
+          to.display(),
+          e
+        )
+      })
+      .expect("directory move failed");
   } else {
-    fs::rename(&from, &to).expect("unable to move");
+    fs::rename(&from, &to)
+      .map_err(|e| {
+        format!(
+          "Failed to rename file from '{}' to '{}': {}",
+          from.display(),
+          to.display(),
+          e
+        )
+      })
+      .expect("file rename failed");
   }
 
   println!("{}", from.to_str().unwrap());

--- a/src/utils/move_file.rs
+++ b/src/utils/move_file.rs
@@ -1,3 +1,4 @@
+use fs_extra::dir;
 use std::fs;
 use std::path::PathBuf;
 
@@ -7,7 +8,14 @@ pub fn move_file(from: PathBuf, to: String) {
   let file_name = file_name.to_str().unwrap();
   let to = format!("{to}/{file_name}");
 
-  fs::rename(&from, &to).expect("unable to move");
+  if from.is_dir() {
+    let mut options = dir::CopyOptions::new();
+    options.copy_inside = true;
+    dir::move_dir(&from, &to, &options).expect("unable to move");
+  } else {
+    fs::rename(&from, &to).expect("unable to move");
+  }
+
   println!("{}", from.to_str().unwrap());
   println!("moved to");
   println!("{to}");


### PR DESCRIPTION
The `move_file` function was panicking when trying to move a non-empty directory. This commit fixes the issue by using the `fs_extra` crate to recursively move directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced file moving functionality to support both files and directories with improved handling and error reporting.

* **Chores**
  * Added a new dependency to support advanced directory operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->