### PR TITLE
Modernize project and improve code quality and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +69,52 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "directories"
@@ -38,6 +140,8 @@ dependencies = [
 name = "file-organizer"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap",
  "directories",
  "fs_extra",
 ]
@@ -60,6 +164,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +190,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -103,6 +225,12 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -142,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,3 +302,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "file-organizer"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 directories = "4.0.1"
 fs_extra = "1.3.0"
-
+anyhow = "1.0"
+clap = { version = "4.0", features = ["derive"] }

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -8,10 +8,10 @@ pub static DIRS: [&str; 7] = [
   "Executable",
   "Other",
 ];
-pub static TEXT_EXT: [&str; 8] =
-  ["md", "txt", "doc", "docx", "pptx", "odf", "docm", "pdf"];
-pub static IMAGE_EXT: [&str; 9] = [
-  "jpg", "png", "jpeg", "gif", "tiff", "psd", "bmp", "ico", "svg",
+pub static TEXT_EXT: [&str; 12] =
+  ["md", "txt", "doc", "docx", "pptx", "odf", "docm", "pdf", "xlsx", "csv", "json", "yaml"];
+pub static IMAGE_EXT: [&str; 10] = [
+  "jpg", "png", "jpeg", "gif", "tiff", "psd", "bmp", "ico", "svg", "webp",
 ];
 pub static AUDIO_EXT: [&str; 4] = ["mp3", "wma", "wav", "flac"];
 pub static VIDEO_EXT: [&str; 6] = ["mov", "mp4", "avi", "mkv", "flv", "wmv"];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,42 @@
-use std::env;
+use anyhow::Result;
+use clap::Parser;
+use std::path::PathBuf;
 
 mod globals;
 mod utils;
 
-fn main() {
-  let args: Vec<String> = env::args().collect();
-  let args: Vec<&str> = args.iter().map(|v| v.as_str()).collect();
-  let dir = utils::get_download_dir(&args);
-  utils::set_write_permissions(&dir);
-  utils::create_dirs(&dir);
-  utils::organize(&dir);
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Directory to organize (defaults to ~/Downloads)
+    directory: Option<PathBuf>,
+
+    /// Only list actions without executing them
+    #[arg(short, long)]
+    dry_run: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let dir = if let Some(path) = args.directory {
+        path.canonicalize()?
+    } else {
+        // We use the original logic but adapted
+        // Actually I'll call get_download_dir with empty args or similar
+        // or just re-implement here for simplicity since we use clap now.
+        utils::get_default_download_dir()?
+    };
+
+    println!("Organizing directory: {}", dir.display());
+    if args.dry_run {
+        println!("Running in DRY RUN mode");
+    }
+
+    utils::set_write_permissions(&dir, args.dry_run)?;
+    utils::create_dirs(&dir, args.dry_run)?;
+    utils::organize(&dir, args.dry_run)?;
+
+    println!("Done!");
+    Ok(())
 }

--- a/src/utils/get_download_dir.rs
+++ b/src/utils/get_download_dir.rs
@@ -1,47 +1,29 @@
 use crate::globals;
+use anyhow::{anyhow, bail, Result};
 use directories::UserDirs;
-use std::path::Path;
+use std::path::PathBuf;
 
-static DOWNLOAD_DIR_NOT_FOUND: &str = "Downloads directory not found";
+pub fn get_default_download_dir() -> Result<PathBuf> {
+  let user = UserDirs::new().ok_or_else(|| anyhow!("Could not determine user directories"))?;
+  let download = user.download_dir();
 
-pub fn get_download_dir(args: &[&str]) -> String {
-  match args.len() {
-    1 => {
-      let user = UserDirs::new().unwrap();
-      let download = user.download_dir();
+  match download {
+    None => {
+      let home = user.home_dir();
+      let download = home.join(globals::DIR);
 
-      match download {
-        None => {
-          let home = user.home_dir();
-          let download = format!("{}/{}", home.display(), globals::DIR);
-          let download = Path::new(&download);
-
-          if !download.exists() {
-            panic!("{}", DOWNLOAD_DIR_NOT_FOUND);
-          }
-
-          download.to_str().unwrap().to_string()
-        },
-        Some(dir) => {
-          if !dir.exists() {
-            panic!("{}", DOWNLOAD_DIR_NOT_FOUND);
-          }
-
-          dir.to_str().unwrap().to_string()
-        },
+      if !download.exists() {
+        bail!("Downloads directory not found at {}", download.display());
       }
-    },
-    2 => {
-      let download = Path::new(&args[1]);
-      let download = match download.canonicalize() {
-        Ok(dir) => dir,
-        Err(_) => panic!("{}", DOWNLOAD_DIR_NOT_FOUND),
-      };
 
-      download.to_str().unwrap().to_string()
+      Ok(download)
     },
-    _ => {
-      panic!("to mutch arguments");
+    Some(dir) => {
+      if !dir.exists() {
+        bail!("Downloads directory not found at {}", dir.display());
+      }
+
+      Ok(dir.to_path_buf())
     },
   }
 }
@@ -49,34 +31,14 @@ pub fn get_download_dir(args: &[&str]) -> String {
 #[cfg(test)]
 mod test {
   use super::*;
-  use std::panic::catch_unwind;
 
   #[test]
-  fn without_arguments() {
-    let args = vec![""];
-    let result = catch_unwind(|| get_download_dir(&args));
-
+  fn test_get_default_download_dir() {
+    let result = get_default_download_dir();
+    // We can't guarantee it exists in the CI environment, but we can check if it returns Ok or Err gracefully
     match result {
-      Ok(dir) => assert!(dir.contains("Downloads")),
-      Err(_) => assert!(result.is_err()),
+        Ok(path) => assert!(path.to_str().unwrap().contains("Downloads") || path.to_str().unwrap().contains("downloads")),
+        Err(e) => println!("Could not find downloads dir: {}", e),
     }
-  }
-
-  #[test]
-  fn with_one_argument() {
-    let args = vec!["", "Downloads"];
-    let result = catch_unwind(|| get_download_dir(&args));
-
-    match result {
-      Ok(dir) => assert!(dir.contains("Downloads")),
-      Err(_) => assert!(result.is_err()),
-    }
-  }
-
-  #[test]
-  #[should_panic]
-  fn pass_more_of_one_argument() {
-    let args = vec!["", "Foo", "Bar"];
-    get_download_dir(&args);
   }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,7 @@ mod set_write_permissions;
 
 pub use self::create_dirs::create_dirs;
 pub use self::files_extension::files_extension;
-pub use self::get_download_dir::get_download_dir;
+pub use self::get_download_dir::get_default_download_dir;
 pub use self::move_file::move_file;
 pub use self::organize::organize;
 pub use self::set_write_permissions::set_write_permissions;

--- a/src/utils/set_write_permissions.rs
+++ b/src/utils/set_write_permissions.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
@@ -5,14 +6,23 @@ use std::path::Path;
 // which is not ideal. However, for the purpose of this script, which is to organize the user's "Downloads" folder,
 // simply making the files writable is probably sufficient and less likely to cause issues.
 #[allow(clippy::permissions_set_readonly_false)]
-pub fn set_write_permissions<P: AsRef<Path>>(path: P) {
-  let dir = fs::read_dir(path).expect("unable to open");
+pub fn set_write_permissions<P: AsRef<Path>>(path: P, dry_run: bool) -> Result<()> {
+  let path = path.as_ref();
+  if dry_run {
+    println!("[DRY RUN] Would set write permissions for files in {}", path.display());
+    return Ok(());
+  }
+  let dir = fs::read_dir(path)
+    .with_context(|| format!("Unable to open directory for permissions: {}", path.display()))?;
 
   for entry in dir {
-    let entry = entry.unwrap().path();
-    let mt = fs::metadata(&entry).expect("unable to get metadata");
+    let entry = entry.with_context(|| "Error reading directory entry")?.path();
+    let mt = fs::metadata(&entry)
+      .with_context(|| format!("Unable to get metadata for {}", entry.display()))?;
     let mut perms = mt.permissions();
     perms.set_readonly(false);
-    fs::set_permissions(entry, perms).expect("unable to set permmissions");
+    fs::set_permissions(&entry, perms)
+      .with_context(|| format!("Unable to set permissions for {}", entry.display()))?;
   }
+  Ok(())
 }


### PR DESCRIPTION
This PR modernizes the file-organizer tool by:
1. Updating to Rust 2021 edition and adding `anyhow` and `clap` dependencies.
2. Replacing `panic!` and `unwrap()` with proper `Result` based error handling.
3. Improving the CLI with `clap`, allowing an optional directory argument and a new `--dry-run` flag.
4. Making extension matching case-insensitive.
5. Adding more common file extensions to the organization categories.
6. Fixing typos in error messages and improving path handling with `PathBuf`.
7. Adding unit tests for case-insensitivity and default directory retrieval.

---
*PR created automatically by Jules for task [3611107301454634100](https://jules.google.com/task/3611107301454634100) started by @yacosta738*